### PR TITLE
Use percentage for html font-size

### DIFF
--- a/src/content/static/styles/tufte.css
+++ b/src/content/static/styles/tufte.css
@@ -36,7 +36,7 @@
 }
 
 /* Tufte CSS styles */
-html { font-size: 15px; }
+html { font-size: 93.75%; }
 
 body { width: 87.5%;
        margin-left: auto;


### PR DESCRIPTION
Setting `html { font-size: 15px; }` creates an accessibility issue, in that it prevents users' default font sizes from being applied. The simplest way around this is to instead set `html { font-size: 93.75%; }`. The tradeoff for this—possible incompatibility with other CSS libraries—doesn't apply here.